### PR TITLE
Fix: Stabilize PKCS12 password in CASignedCert

### DIFF
--- a/authority.py
+++ b/authority.py
@@ -485,8 +485,18 @@ class CASignedCert(pulumi.ComponentResource):
 
         if "client_auth" in allowed_uses and "server_auth" not in allowed_uses:
             # Create a password encrypted PKCS#12 object if only client_auth
+            # Use the certificate's PEM and key PEM as keepers.
+            # If the cert or key changes, a new password will be generated.
+            password_keepers = {
+                "cert_pem": self.cert.cert_pem,
+                "key_pem": self.key.private_key_pem,
+            }
             self.pkcs12_password = random.RandomPassword(
-                "{}_pkcs12_password".format(name), special=False, length=24
+                "{}_pkcs12_password".format(name),
+                length=24,
+                special=False,
+                keepers=password_keepers,
+                opts=pulumi.ResourceOptions(parent=self),
             )
             self.pkcs12 = pulumi.Output.all(
                 key=self.key.private_key_pem,

--- a/tools.py
+++ b/tools.py
@@ -659,6 +659,7 @@ class DataExport(pulumi.ComponentResource):
             dir=project_dir,
             triggers=[
                 data.apply(lambda x: hashlib.sha256(str(x).encode("utf-8")).hexdigest()),
+                self.filename, # Ensure changes to filename also trigger recreation
             ],
         )
         self.register_outputs({})


### PR DESCRIPTION
Modified CASignedCert to use `keepers` for the `random.RandomPassword` that generates the PKCS12 bundle password. The keepers are set to the certificate PEM and the private key PEM.

This ensures that the password, and therefore the resulting PKCS12 bundle, remains stable as long as the underlying certificate and key do not change. This should prevent downstream resources like DataExport from being re-triggered unnecessarily when client certificate data is stable.